### PR TITLE
Second Tuesday of the month generaly conflicts with WordPress DC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@ BeerJS DC
 =========
 
 BeerJS DC is a welcoming get-together for everyone who wants to learn about JavaScript. 
-We meet the second Tuesday of the month. 
+We meet the second Tuesday and third Wednesday of the month. 
 That's all the planning we have: whoever shows up decides what happens.
 
 **Our first meeting will be June 11 at [Matchbox Chinatown](http://www.yelp.com/biz/matchbox-chinatown-washington)**
+**Our second meeting will be June 19 at [The Big Hunt](http://thebighunt.net/) in Dupont**
 
 Want to join?
 -------------


### PR DESCRIPTION
I recognize that there isn't significant overlap (Based on attendance at both WordPress DC and jQuery DC, I would say < 10), Perhaps we should have Beer.js more often than once per month in order to prevent overlap with other meetups? 
